### PR TITLE
Fix eventhandler_register_addr

### DIFF
--- a/kpayload/include/offsets/1200-1202.h
+++ b/kpayload/include/offsets/1200-1202.h
@@ -31,7 +31,7 @@
 #define memset_addr                      0x001FA140
 #define strlen_addr                      0x0036AB30
 #define printf_addr                      0x002E03E0
-#define eventhandler_register_addr       0x00224180
+#define eventhandler_register_addr       0x00224110
 
 // Fself
 #define sceSblACMgrGetPathId_addr        0x003B2D80


### PR DESCRIPTION
Based on comparing 11.00 and 12.02 kernel dumps.