### PR TITLE
Ditch patterns for syscall and read syscall pointer directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      zip: ps4-hen-vtx
+      zip: ps4-hen-vtx.7z
       zip_glob: ps4-hen-*.bin
     steps:
       - name: Checkout repository
@@ -38,7 +38,7 @@ jobs:
           for VERSION in $VERSIONS; do
             ./build.sh $VERSION
           done
-          zip ${{ env.zip }}.zip ${{ env.zip_glob }}
+          7z a -mx9 ${{ env.zip }} ${{ env.zip_glob }}
 
       - name: Upload payload
         if: github.event_name == 'pull_request'
@@ -57,6 +57,6 @@ jobs:
             PRERELEASE_FLAG="-p"
           fi
 
-          gh release create $PRERELEASE_FLAG HEN-1.0${{ github.run_number }} ps4-hen-vtx.zip \
+          gh release create $PRERELEASE_FLAG HEN-1.0${{ github.run_number }} ${{ env.zip }} \
             --target ${{ github.sha }} \
             -t HEN-1.0${{ github.run_number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,22 @@ jobs:
           zip ${{ env.zip }}.zip ${{ env.zip_glob }}
 
       - name: Upload payload
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: ${{ env.zip }}
+          name: ps4-hen-vtx
           path: ${{ env.zip_glob }}
 
-      - name: Release for branch Multi-HEN
-        if: github.event_name == 'push' && github.ref == 'refs/heads/Multi-HEN'
+      - name: Release
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create HEN-1.0${{ github.run_number }} ps4-hen-vtx.zip --target ${{ github.sha }} -t HEN-1.0${{ github.run_number }}
+          PRERELEASE_FLAG=""
+          if [ "${GITHUB_REF}" != "refs/heads/Multi-HEN" ]; then
+            PRERELEASE_FLAG="-p"
+          fi
+
+          gh release create $PRERELEASE_FLAG HEN-1.0${{ github.run_number }} ps4-hen-vtx.zip \
+            --target ${{ github.sha }} \
+            -t HEN-1.0${{ github.run_number }}

--- a/download_prx.sh
+++ b/download_prx.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 c=$PWD
-cd installer/build
+b=installer/build
+mkdir -p $b
+cd $b
 f=plugins.zip
 curl -fLJO https://github.com/illusion0001/ps4-hen-plugins/releases/latest/download/$f
 unzip $f

--- a/kpayload/source/hooks.c
+++ b/kpayload/source/hooks.c
@@ -307,8 +307,7 @@ PAYLOAD_CODE int sys_dynlib_load_prx_hook(struct thread *td, struct dynlib_load_
 {
     int r = sys_dynlib_load_prx(td, args);
     // https://github.com/OpenOrbis/mira-project/blob/d8cc5790f08f93267354c2370eb3879edba0aa98/kernel/src/Plugins/Substitute/Substitute.cpp#L1003
-    const char *ttemp = (const char *)((uint64_t)td->td_proc + 0x390);
-    const char *titleid = ttemp ? ttemp : "?";
+    const char *titleid = td->td_proc->titleid;
     const char *p = args->prx_path ? args->prx_path : "";
     printf("%s td_name %s titleid %s prx %s\n", __FUNCTION__, td->td_name, titleid, p);
     if (strstr(p, "/app0/sce_module/libc.prx"))
@@ -340,7 +339,6 @@ PAYLOAD_CODE int sys_dynlib_load_prx_hook(struct thread *td, struct dynlib_load_
     // dummy process to load server prx into
     else if (strstr(p, "/common/lib/libSceSysmodule.sprx") && strstr(td->td_name, "ScePartyDaemonMain"))
     {
-        const int handle_out = args->handle_out ? *args->handle_out : 0;
         struct dynlib_load_prx_args my_args = {};
         int handle = 0;
         // TODO: Upload this file to disk
@@ -364,7 +362,7 @@ PAYLOAD_CODE int sys_dynlib_load_prx_hook(struct thread *td, struct dynlib_load_
             proc_rw_mem(td->td_proc, (void *)init_env_ptr, sizeof(jmp), jmp, 0, 1);
             proc_rw_mem(td->td_proc, (void *)(init_env_ptr + sizeof(jmp)), sizeof(plugin_load_ptr), &plugin_load_ptr, 0, 1);
         }
-        printf("%s init env 0x%lx plugin load 0x%lx\n", ttemp, init_env_ptr, plugin_load_ptr);
+        printf("%s init env 0x%lx plugin load 0x%lx\n", titleid, init_env_ptr, plugin_load_ptr);
     }
     return r;
 }

--- a/kpayload/source/hooks.c
+++ b/kpayload/source/hooks.c
@@ -169,6 +169,12 @@ PAYLOAD_CODE void install_syscall(uint32_t n, void *func)
     p->sy_thrcnt = 1;
 }
 
+PAYLOAD_CODE void *get_syscall(uint64_t n)
+{
+    struct sysent *p = &SYSENT[n];
+    return p->sy_call;
+}
+
 int sys_proc_info_handle(struct proc *p, struct sys_proc_info_args *args)
 {
     args->pid = p->pid;
@@ -379,8 +385,6 @@ PAYLOAD_CODE void install_syscall_hooks()
     install_syscall(107, sys_proc_list);
     install_syscall(108, sys_proc_rw);
     install_syscall(109, sys_proc_cmd);
-    printf("sys_dynlib_load_prx %p\n", sys_dynlib_load_prx);
-    printf("sys_dynlib_dlsym %p\n", sys_dynlib_dlsym);
     if (sys_dynlib_load_prx && sys_dynlib_dlsym)
     {
         install_syscall(594, sys_dynlib_load_prx_hook);

--- a/kpayload/source/main.c
+++ b/kpayload/source/main.c
@@ -284,7 +284,7 @@ static PAYLOAD_CODE uint64_t get_kernel_size(uint64_t kernel_base)
 	return max - 0xFFFFFFFF82200000;
 }
 
-PAYLOAD_CODE static void resolve_patterns()
+PAYLOAD_CODE static void resolve_patterns(void)
 {
 	uint64_t flags, cr0;
 	cr0 = readCr0();

--- a/kpayload/source/main.c
+++ b/kpayload/source/main.c
@@ -284,8 +284,17 @@ static PAYLOAD_CODE uint64_t get_kernel_size(uint64_t kernel_base)
 	return max - 0xFFFFFFFF82200000;
 }
 
+PAYLOAD_CODE extern void *get_syscall(uint64_t n);
+
+PAYLOAD_CODE static void resolve_syscall(void)
+{
+	sys_dynlib_load_prx = get_syscall(594);
+	sys_dynlib_dlsym = get_syscall(591);
+}
+
 PAYLOAD_CODE static void resolve_patterns(void)
 {
+	return;
 	uint64_t flags, cr0;
 	cr0 = readCr0();
 	writeCr0(cr0 & ~X86_CR0_WP);
@@ -370,6 +379,7 @@ PAYLOAD_CODE void my_entrypoint()
 {
 	resolve_kdlsym();
 	resolve_patterns();
+	resolve_syscall();
 	install_fself_hooks();
 	install_fpkg_hooks();
 	install_patches();


### PR DESCRIPTION
It seems that disable write protect causes a page fault when reading syscall table, without it, it reads fine.